### PR TITLE
Adding API Token Auth

### DIFF
--- a/product_registry/settings.py
+++ b/product_registry/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_mysql',
     'rest_framework',
+    'rest_framework.authtoken',
     'server'
 ]
 
@@ -116,7 +117,18 @@ AUTH_PASSWORD_VALIDATORS = [
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'server.pagination.ProductsPagination',
     'PAGE_SIZE': 20,
-    'MAX_LIMIT': 100
+    'MAX_LIMIT': 100,
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'server.authentication.APIToken'
+    ],
+}
+
+SUNSPEC = {
+    'MEMBERSHIP_GROUP_NAME': 'SunSpecMembers',
+    'API_PERMISSION_DENIED_MESSAGE': (
+        'You must have an active SunSpec membership to use this API. '
+        'Please email support@sunspec.org to sign up.'
+    ),
 }
 
 AUTH_USER_MODEL = 'server.User'

--- a/server/authentication.py
+++ b/server/authentication.py
@@ -1,0 +1,7 @@
+from rest_framework import authentication
+
+from server import models
+
+
+class APIToken(authentication.TokenAuthentication):
+    model = models.APIToken

--- a/server/models.py
+++ b/server/models.py
@@ -7,6 +7,8 @@ from django.contrib import auth
 
 from django_mysql import models as mysql_models
 
+import rest_framework
+
 import server.ob_item_types as obit
 
 
@@ -389,3 +391,8 @@ class EditURL(Edit):
 class EditUUID(Edit):
     FieldValue = models.UUIDField(blank=True)
     FieldValueOld = models.UUIDField(blank=True)
+
+
+class APIToken(rest_framework.authtoken.models.Token):
+    expires = models.DateTimeField(default=None, blank=True, null=True)
+    is_active = models.BooleanField(default=True, blank=True)

--- a/server/permissions.py
+++ b/server/permissions.py
@@ -1,0 +1,24 @@
+import django
+from django.conf import settings
+from rest_framework import permissions
+
+
+class IsSunSpecMember(permissions.BasePermission):
+    message = settings.SUNSPEC['API_PERMISSION_DENIED_MESSAGE']
+
+    def has_permission(self, request, view):
+        return request.user.groups.filter(name=settings.SUNSPEC['MEMBERSHIP_GROUP_NAME']).exists()
+
+
+class IsAPITokenActive(permissions.BasePermission):
+    message = settings.SUNSPEC['API_PERMISSION_DENIED_MESSAGE']
+
+    def has_permission(self, request, view):
+        return request.auth.is_active
+
+
+class IsAPITokenNotExpired(permissions.BasePermission):
+    message = settings.SUNSPEC['API_PERMISSION_DENIED_MESSAGE']
+
+    def has_permission(self, request, view):
+        return request.auth.expires is None or request.auth.expires >= django.utils.timezone.now()

--- a/server/views_api.py
+++ b/server/views_api.py
@@ -4,7 +4,10 @@ from django import db, conf, shortcuts
 from django.templatetags import static
 from rest_framework import response, decorators
 
-from server import models, ob_item_types as obit, serializers, pagination
+from server import (
+    models, ob_item_types as obit, serializers, pagination, permissions,
+    authentication
+)
 
 
 PARAM_OFFSET_SUBSTITUTEPRODUCTS = 'offset_SubstituteProducts'
@@ -217,6 +220,8 @@ def get_product_id(kwargs):
 
 
 @decorators.api_view(['GET', 'POST'])
+@decorators.authentication_classes([authentication.APIToken])
+@decorators.permission_classes([permissions.IsSunSpecMember, permissions.IsAPITokenActive, permissions.IsAPITokenNotExpired])
 def product_list(request):
     if request.method == 'POST':
         product_id_groups, max_group_size, debug_dict = _product_list_query(request)
@@ -257,6 +262,8 @@ def _product_list_query(request):
 
 
 @decorators.api_view(['GET'])
+@decorators.authentication_classes([authentication.APIToken])
+@decorators.permission_classes([permissions.IsSunSpecMember, permissions.IsAPITokenActive, permissions.IsAPITokenNotExpired])
 def product_detail(request, **kwargs):
     for p in obit.get_schema_subclasses('Product'):
         if len(res := list(serializers.serialize_by_ids(p, [get_product_id(kwargs)]).values())) > 0:


### PR DESCRIPTION
Closes #6.

Adds API Token authentication for the Product API.

To call the API, a user must:
- Be a SunSpec member (part of the SunSpec Member Django user group)
- Have an API token that is active.
- Have an API token that is not expired.

A user not in the SunSpec Member Django user group should not have an API token, but this is not enforced in the code yet.

Anonymous users and non-SunSpec Member users cannot call the API.